### PR TITLE
Fix typo in the repo's URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "koa http request & response logger",
   "repository": {
     "type": "git",
-    "url": "https://github.com/vesln/koa-http-log"
+    "url": "https://github.com/vesln/koa-http-logger"
   },
   "author": "Veselin Todorov <hi@vesln.com>",
   "homepage": "https://github.com/vesln/koa-http-logger",


### PR DESCRIPTION
Incorrect URL appears in the project's page on NPM,
giving a 404.
